### PR TITLE
updates for 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository facilitates the combination of user content with central style and formatting provided by FNAL.
 
 Users should enter content in the following locations (items 4-8 cover the required appendices):
-1. [info.tex](./info.tex): details for cover page
+1. [info.tex](./info.tex): details for cover page, and switches to enable/disable a table of contents and line numbering
 2. [packages.tex](./packages.tex): any additional packages used
 3. [content.tex](./content.tex): the actual proposal content
 4. [biblio.tex](./biblio.tex): references

--- a/README.md
+++ b/README.md
@@ -10,18 +10,27 @@ Users should enter content in the following locations (items 4-10 cover the requ
 5. [facilities.tex](./facilities.tex): facilities
 6. [equipment.tex](./equipment.tex): equipment
 7. [dataplan.tex](./dataplan.tex): data management plan
-8. [pierplan.tex](./pierplan.tex): PIER plan
-9. [other.tex](./other.tex): other attachments (e.g. letters of collaboration using the `\collabletter{}` command)
-10. [labrenewal.tex](./labrenewal.tex): national lab "renewals"
+8. [other.tex](./other.tex): other attachments (e.g. letters of collaboration using the `\collabletter{}` command)
+
+## References
+The template is set up to use BibLaTeX+Biber, with the bibliogrpahy generated automatically from records that you dump in [references.bib](./references.bib).
+If you prefer, by commenting/uncommenting code in [biblio.tex](./biblio.tex) you can opt to format your bibliography manually, with entries that you list in the `\thebibliography` block in that file.
 
 ## Compilation
 
-For standalone use, basic compilation is as simple as:
+For standalone use, basic compilation is as simple as (if using Biber):
+```bash
+pdflatex main.tex
+biber main
+pdflatex main.tex
+```
+
+or (if manually formatting the bibliography):
 ```bash
 pdflatex main.tex
 ```
 
-Depending on your use of references, bibliography tools, etc., you may need to run `pdflatex` multiple times and/or run `bibtex` explicitly.
+Depending on your use of references, bibliography tools, etc., you may need to run `pdflatex` and/or `biber` multiple times (following cues from the compilation messages).
 
 This repository can also be used as a base to create new projects on [Overleaf](https://overleaf.com).
 There are several methods for this:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Users should enter content in the following locations (items 4-8 cover the requi
 8. [other.tex](./other.tex): other attachments (e.g. letters of collaboration using the `\collabletter{}` command)
 
 ## References
-The template is set up to use BibLaTeX+Biber, with the bibliogrpahy generated automatically from records that you dump in [references.bib](./references.bib).
+The template is set up to use BibLaTeX+Biber, with the bibliography generated automatically from records that you dump in [references.bib](./references.bib).
 If you prefer, by commenting/uncommenting code in [biblio.tex](./biblio.tex) you can opt to format your bibliography manually, with entries that you list in the `\thebibliography` block in that file.
 
 ## Compilation

--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ This repository is set up on GitHub as a "template repository", so you can creat
 After the lab directorate reviews and approves your proposal, you will get a signed copy of your cover page.
 You will need to merge this back into your proposal before submitting in grants.gov.
 
-This is a way to do it if you're on Linux, which produces a PDF file that grants.gov considers a "read-only PDF file" (so the contents will be visible in the preview PDF that grants.gov generates), and retains hyperlinks (so reviewers can click on section, citation, and URL links):
-* print-to-PDF the signed cover page (this will strip the electronic signature) to (for example) `signature_printed.pdf`
+This is a way to do it if you're on Linux (from https://tex.stackexchange.com/questions/497624/merging-multiple-pdf-files-without-breaking-hyperlinks), which produces a PDF file that grants.gov considers a "read-only PDF file" (so the contents will be visible in the preview PDF that grants.gov generates), and retains hyperlinks (so reviewers can click on section, citation, and URL links):
+* print-to-PDF the signed cover page (this will strip the electronic signature, but apparently this is fine) to (for example) `signature_printed.pdf`
 * use pdftk to merge: `pdftk A=signature_printed.pdf B=main.pdf cat A B2-end output proposal_merged.pdf`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository facilitates the combination of user content with central style and formatting provided by FNAL.
 
-Users should enter content in the following locations (items 4-10 cover the required appendices):
+Users should enter content in the following locations (items 4-8 cover the required appendices):
 1. [info.tex](./info.tex): details for cover page
 2. [packages.tex](./packages.tex): any additional packages used
 3. [content.tex](./content.tex): the actual proposal content

--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ There are several methods for this:
 2. Upload Project (download [zip file](https://github.com/kpedro88/FNAL_ECA_Proposal_Template/archive/refs/heads/main.zip))
 
 This repository is set up on GitHub as a "template repository", so you can create your own repository based on it *without* needing to make a public fork, if desirable.
+
+## Merging the signed cover page
+After the lab directorate reviews and approves your proposal, you will get a signed copy of your cover page.
+You will need to merge this back into your proposal before submitting in grants.gov.
+
+This is a way to do it if you're on Linux, which produces a PDF file that grants.gov considers a "read-only PDF file" (so the contents will be visible in the preview PDF that grants.gov generates), and retains hyperlinks (so reviewers can click on section, citation, and URL links):
+* print-to-PDF the signed cover page (this will strip the electronic signature) to (for example) `signature_printed.pdf`
+* use pdftk to merge: `pdftk A=signature_printed.pdf B=main.pdf cat A B2-end output proposal_merged.pdf`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository facilitates the combination of user content with central style and formatting provided by FNAL.
 
 Users should enter content in the following locations (items 4-8 cover the required appendices):
-1. [info.tex](./info.tex): details for cover page, and switches to enable/disable a table of contents and line numbering
+1. [info.tex](./info.tex): details for cover page, and flags to enable/disable table of contents, line numbering, and biblatex 
 2. [packages.tex](./packages.tex): any additional packages used
 3. [content.tex](./content.tex): the actual proposal content
 4. [biblio.tex](./biblio.tex): references
@@ -14,7 +14,7 @@ Users should enter content in the following locations (items 4-8 cover the requi
 
 ## References
 The template is set up to use BibLaTeX+Biber, with the bibliography generated automatically from records that you dump in [references.bib](./references.bib).
-If you prefer, by commenting/uncommenting code in [biblio.tex](./biblio.tex) you can opt to format your bibliography manually, with entries that you list in the `\thebibliography` block in that file.
+If you prefer, by toggling a flag in [info.tex](./info.tex) you can opt to format your bibliography manually, with entries that you list in the `\thebibliography` block in [biblio.tex](./biblio.tex).
 
 ## Compilation
 

--- a/base/coverpage.tex
+++ b/base/coverpage.tex
@@ -17,13 +17,13 @@ Postal Address: & P.O. Box 500 / Batavia, IL / 60510\\
 \hline
 Lead PI name, telephone number, email: & \Name, \PhoneFirst.\PhoneLast, \EmailFirst\EmailLast\\
 \hline
-Administrative Point of Contact name, telephone number, email: & Cheryl Stetter, 630.840.4420, cheryl@fnal.gov\\
+Administrative Point of Contact name, telephone number, email: & Kayla Roman, 303.885.0465, kdecker@fnal.gov\\
 \hline
 NOFO Number: & \FOANumber\\
 \hline
 DOE/SC Program Office: & \ProgramOffice\\
 \hline
-Research Area: & \TopicArea\\
+Research Area or Areas: & \TopicArea\\
 \hline
 DOE/SC Program Office Technical Contact: & \ProgramContact\\
 \hline
@@ -35,7 +35,7 @@ Does the PI have tenure: & \PITenure\\
 \hline
 Number of Times Previously Applied: & \NumPrev\\
 \hline
-PAMS Pre-application Number: & \PreproposalNum\\
+PAMS Pre-application Tracking Number: & \PreproposalNum\\
 \hline
 Proposal Contains Data Management Plan in Appendix 4: & Yes\\
 \hline
@@ -45,5 +45,5 @@ Proposal Contains Data Management Plan in Appendix 4: & Yes\\
 \noindent The proposed research idea fits within the scope of SC-funded programs at Fermilab.\\
 \vspace{4\baselineskip}\\
 \noindent\rule{\textwidth}{1pt}\\
-Young-Kee Kim \hfill (Date)\\
-(Interim) Director, Fermi National Accelerator Laboratory
+Norbert Holtkamp \hfill (Date)\\
+Director, Fermi National Accelerator Laboratory

--- a/base/coverpage.tex
+++ b/base/coverpage.tex
@@ -1,5 +1,3 @@
-\input{info}
-
 % from p. 76 of DE-FOA-0003176.pdf
 \begin{table}[!h]
 \centering

--- a/base/style.tex
+++ b/base/style.tex
@@ -19,13 +19,3 @@
 \renewcommand{\headrulewidth}{2pt}
 \renewcommand{\headrule}{\vskip-0.5\baselineskip\hbox to\headwidth{%
     \color{NALblue}\leaders\hrule height \headrulewidth\hfill}}
-
-% blank footnote for Buy America boilerplate
-% https://tex.stackexchange.com/questions/562763/footnote-without-reference
-\let\svthefootnote\thefootnote
-\newcommand\blankfootnote[1]{%
-  \begin{NoHyper}
-    \let\thefootnote\relax\footnotetext{#1}%
-    \let\thefootnote\svthefootnote%
-  \end{NoHyper}
-}

--- a/base/style.tex
+++ b/base/style.tex
@@ -19,3 +19,13 @@
 \renewcommand{\headrulewidth}{2pt}
 \renewcommand{\headrule}{\vskip-0.5\baselineskip\hbox to\headwidth{%
     \color{NALblue}\leaders\hrule height \headrulewidth\hfill}}
+
+% blank footnote for Buy America boilerplate
+% https://tex.stackexchange.com/questions/562763/footnote-without-reference
+\let\svthefootnote\thefootnote
+\newcommand\blankfootnote[1]{%
+  \begin{NoHyper}
+    \let\thefootnote\relax\footnotetext{#1}%
+    \let\thefootnote\svthefootnote%
+  \end{NoHyper}
+}

--- a/biblio.tex
+++ b/biblio.tex
@@ -1,3 +1,11 @@
-\begin{thebibliography}{99}
+% biblatex: do nothing here (just fill references.bib with bibtex records)
+\printbibliography[heading=bibnumbered,title={Bibliography \& References Cited}]
 
-\end{thebibliography}
+% manual formatting: fill this block with a list of \bibitems (as in https://www.overleaf.com/learn/latex/Bibliography_management_with_bibtex#Bibliography:_just_a_list_of_\bibitems)
+%\begin{thebibliography}{99}
+%    \bibitem{p5_2023}
+%        Murayama, H. \emph{et al}.
+%        \emph{Exploring the Quantum Universe: Pathways to Innovation and Discovery in Particle Physics}
+%        (US Department of Energy (USDOE), Washington DC (United States). Energy Information Administration, June 7, 2023).
+%        \url{https://www.osti.gov/biblio/2368847}.
+%\end{thebibliography}

--- a/biblio.tex
+++ b/biblio.tex
@@ -1,14 +1,16 @@
 % NOFO says:
 % Each reference must include the names of all authors (in the same sequence in which they appear in the publication), the article and journal title, book title, volume number, page numbers, and year of publication. For research areas where there are routinely more than 10 coauthors of archival publications, you may use an abbreviated style such as the Physical Review Letters (PRL) convention for citations (listing only the first author). For example, your paper may be listed as, “A Really Important New Result,” A. Aardvark et. al. (MONGO Collaboration), PRL 999. Include only bibliographic citations. Applicants should be especially careful to follow scholarly practices in providing citations for source materials relied upon when preparing any section of the application.
 
+\ifdefined\biblatexflag
 % biblatex: do nothing here (just fill references.bib with bibtex records)
 \printbibliography[heading=bibnumbered,title={Bibliography \& References Cited}]
-
+\else
 % manual formatting: fill this block with a list of \bibitems (as in https://www.overleaf.com/learn/latex/Bibliography_management_with_bibtex#Bibliography:_just_a_list_of_\bibitems)
-%\begin{thebibliography}{99}
-%    \bibitem{p5_2023}
-%        Murayama, H. \emph{et al}.
-%        \emph{Exploring the Quantum Universe: Pathways to Innovation and Discovery in Particle Physics}
-%        (US Department of Energy (USDOE), Washington DC (United States). Energy Information Administration, June 7, 2023).
-%        \url{https://www.osti.gov/biblio/2368847}.
-%\end{thebibliography}
+\begin{thebibliography}{99}
+    \bibitem{p5_2023}
+        Murayama, H. \emph{et al}.
+        \emph{Exploring the Quantum Universe: Pathways to Innovation and Discovery in Particle Physics}
+        (US Department of Energy (USDOE), Washington DC (United States). Energy Information Administration, June 7, 2023).
+        \url{https://www.osti.gov/biblio/2368847}.
+\end{thebibliography}
+\fi

--- a/biblio.tex
+++ b/biblio.tex
@@ -1,3 +1,6 @@
+% NOFO says:
+% Each reference must include the names of all authors (in the same sequence in which they appear in the publication), the article and journal title, book title, volume number, page numbers, and year of publication. For research areas where there are routinely more than 10 coauthors of archival publications, you may use an abbreviated style such as the Physical Review Letters (PRL) convention for citations (listing only the first author). For example, your paper may be listed as, “A Really Important New Result,” A. Aardvark et. al. (MONGO Collaboration), PRL 999. Include only bibliographic citations. Applicants should be especially careful to follow scholarly practices in providing citations for source materials relied upon when preparing any section of the application.
+
 % biblatex: do nothing here (just fill references.bib with bibtex records)
 \printbibliography[heading=bibnumbered,title={Bibliography \& References Cited}]
 

--- a/content.tex
+++ b/content.tex
@@ -5,5 +5,6 @@
 \blankfootnote{This application does not contain any public infrastructure.}
 
 \section{Example section}
+Example content~\cite{p5_2023}!
 \clearpage
 \section{Another section}

--- a/content.tex
+++ b/content.tex
@@ -1,5 +1,9 @@
 % include your own content here directly or with more `input`s
 
+% this boilerplate footnote should appear somewhere in the first 2 pages, per the "Buy America Preference" box in the NOFO and the following advice from DOE SC, 2025:
+% "2 CFR 184 is not applicable to Fermilab. The Buy American provision from the Infrastructure Investment and Jobs Act applies to all Federal financial assistance – but Fermilab is under a contract with DOE. Thus, it would be best for all FNAL proposals to include a statement that 'This application does not contain any public infrastructure.'"
+\blankfootnote{This application does not contain any public infrastructure.}
+
 \section{Example section}
 \clearpage
 \section{Another section}

--- a/info.tex
+++ b/info.tex
@@ -11,7 +11,7 @@
 \def\NumPrev{0}
 \def\PreproposalNum{PRE-0000000000}
 % uncomment below to enable table of contents
-%\def\tocflag{}
+\def\tocflag{}
 % uncomment below to enable linenumbers
 %\def\linenoflag{}
 

--- a/info.tex
+++ b/info.tex
@@ -14,6 +14,8 @@
 \def\PecaseEligible{Yes}
 % uncomment below to enable table of contents
 %\def\tocflag{}
+% uncomment below to enable linenumbers
+%\def\linenoflag{}
 
 % unlikely to change
 \def\PhoneFirst{630.840}

--- a/info.tex
+++ b/info.tex
@@ -10,11 +10,11 @@
 \def\PITenure{No}
 \def\NumPrev{0}
 \def\PreproposalNum{PRE-0000000000}
-% uncomment below to enable table of contents
+% comment out below to disable table of contents
 \def\tocflag{}
 % uncomment below to enable linenumbers
 %\def\linenoflag{}
-% uncomment below to use biblatex instead of \thebibliography (manual formatting)
+% comment out below to use \thebibliography (manual formatting) instead of biblatex
 \def\biblatexflag{}
 
 % unlikely to change

--- a/info.tex
+++ b/info.tex
@@ -20,4 +20,4 @@
 % unlikely to change
 \def\PhoneFirst{630.840}
 \def\EmailLast{@fnal.gov}
-\def\FOANumber{DE-FOA-0003450}
+\def\FOANumber{DE-FOA-0003602}

--- a/info.tex
+++ b/info.tex
@@ -14,6 +14,8 @@
 \def\tocflag{}
 % uncomment below to enable linenumbers
 %\def\linenoflag{}
+% uncomment below to use biblatex instead of \thebibliography (manual formatting)
+\def\biblatexflag{}
 
 % unlikely to change
 \def\PhoneFirst{630.840}

--- a/info.tex
+++ b/info.tex
@@ -6,12 +6,10 @@
 \def\TopicArea{Physics}
 \def\ProgramContact{John Snow}
 \def\YearPhD{2015}
-\def\ExtensionReq{No}
 \def\UnivTenureTrack{Not at a University}
 \def\PITenure{No}
 \def\NumPrev{0}
 \def\PreproposalNum{PRE-0000000000}
-\def\PecaseEligible{Yes}
 % uncomment below to enable table of contents
 %\def\tocflag{}
 % uncomment below to enable linenumbers

--- a/main.tex
+++ b/main.tex
@@ -9,6 +9,7 @@
 \usepackage[table]{xcolor}
 \usepackage{fullpage}
 \usepackage{titlesec}
+\usepackage{lineno}
 \usepackage{array}
 \usepackage{etoolbox, pdfpages}
 \patchcmd{\thebibliography}{\section *{\refname }}{\section{\refname}\label{sec:biblio}}{}{}

--- a/main.tex
+++ b/main.tex
@@ -89,7 +89,10 @@
 % 1 page max, optional
 \input{synergy}
 
-% Transparency of Foreign Connections: not required for national labs
+\clearpage
+\section{Transparency of Foreign Connections}
+% Transparency of Foreign Connections: not required for national labs, but we include this to be safe
+The applicant is a U.S. National Laboratory and is thus exempt from disclosure. There are no subrecipients.
 
 \clearpage
 \section{Other Attachments}\label{sec:other}

--- a/main.tex
+++ b/main.tex
@@ -117,8 +117,8 @@
 
 \clearpage
 \section{Transparency of Foreign Connections}
-% Transparency of Foreign Connections: not required for national labs, but we include this to be safe
-The applicant is a U.S. National Laboratory and is thus exempt from disclosure. There are no subrecipients.
+% Transparency of Foreign Connections: not required for national labs, DOE says we may omit the appendix in its entirety or use the boilerplate below
+The applicant institution is a U.S. National Laboratory and is thus exempt from disclosure. There are no subrecipients.
 
 \clearpage
 \section{Other Attachments}\label{sec:other}

--- a/main.tex
+++ b/main.tex
@@ -18,8 +18,14 @@
 \setlength{\pdfpagewidth}{8.5in}
 \setlength{\pdfpageheight}{11in}
 \setlength{\parskip}{0pt}
+
 \titlespacing*{\section}{0pt}{0pt}{0pt}
 \titleformat{\section}{\normalfont\fontsize{11}{15}\bfseries}{\thesection}{1em}{}
+\titlespacing*{\subsection}{0pt}{0pt}{0pt}
+\titleformat{\subsection}{\normalfont\fontsize{11}{15}\bfseries}{\thesubsection}{1em}{}
+\titlespacing*{\subsubsection}{0pt}{0pt}{0pt}
+\titleformat{\subsubsection}{\normalfont\fontsize{11}{15}\bfseries}{\thesubsubsection}{1em}{}
+
 \setlength{\baselineskip}{13pt}
 
 \input{packages}

--- a/main.tex
+++ b/main.tex
@@ -88,7 +88,7 @@
 \input{biblio}
 \clearpage
 
-\section{Facilities and Other Resources}\label{sec:facilities}
+\section{Facilities \& Other Resources}\label{sec:facilities}
 % no limit
 \input{facilities}
 
@@ -97,7 +97,7 @@
 \input{equipment}
 
 \clearpage
-\section{Data Management Plan}\label{sec:dataplan}
+\section{Data Management and Sharing Plan}\label{sec:dataplan}
 % 2 pages max
 \input{dataplan}
 

--- a/main.tex
+++ b/main.tex
@@ -13,15 +13,24 @@
 \usepackage{array}
 \usepackage{etoolbox, pdfpages}
 
-% bibliography, NOFO says:
-% Each reference must include the names of all authors (in the same sequence in which they appear in the publication), the article and journal title, book title, volume number, page numbers, and year of publication. For research areas where there are routinely more than 10 coauthors of archival publications, you may use an abbreviated style such as the Physical Review Letters (PRL) convention for citations (listing only the first author). For example, your paper may be listed as, “A Really Important New Result,” A. Aardvark et. al. (MONGO Collaboration), PRL 999. Include only bibliographic citations. Applicants should be especially careful to follow scholarly practices in providing citations for source materials relied upon when preparing any section of the application.
 % for biblatex (default)
 \usepackage[backend=biber,style=nature,sorting=none,maxbibnames=11]{biblatex}
 \addbibresource{references.bib}
-% for \thebibliography (look in biblio.tex)
+% for \thebibliography (switch in biblio.tex)
 \patchcmd{\thebibliography}{\section *{\refname }}{\section{\refname}\label{sec:biblio}}{}{}
 
 \newcommand{\collabletter}[1]{\includepdf[pages=-, pagecommand={\thispagestyle{empty}\rfoot{\thepage}}]{#1}\clearpage}
+
+% blank footnote for Buy America boilerplate
+% https://tex.stackexchange.com/questions/562763/footnote-without-reference
+\let\svthefootnote\thefootnote
+\newcommand\blankfootnote[1]{%
+  \begin{NoHyper}
+    \let\thefootnote\relax\footnotetext{#1}%
+    \let\thefootnote\svthefootnote%
+  \end{NoHyper}
+}
+
 \pdfminorversion=7
 
 \setlength{\pdfpagewidth}{8.5in}

--- a/main.tex
+++ b/main.tex
@@ -56,6 +56,10 @@
 \setlength{\nsfoffset}{\headheight}
 \addtolength{\nsfoffset}{\baselineskip}
 
+\ifdefined\linenoflag
+\linenumbers
+\fi
+
 % to host your content
 \input{content}
 

--- a/main.tex
+++ b/main.tex
@@ -1,5 +1,7 @@
 \documentclass[11pt]{article}
 
+\input{info}
+
 % default packages
 \usepackage[english]{babel}
 \usepackage[letterpaper,margin=1in]{geometry}
@@ -10,14 +12,18 @@
 \usepackage{fullpage}
 \usepackage{titlesec}
 \usepackage{lineno}
+\usepackage{csquotes}
 \usepackage{array}
 \usepackage{etoolbox, pdfpages}
 
+\ifdefined\biblatexflag
 % for biblatex (default)
 \usepackage[backend=biber,style=nature,sorting=none,maxbibnames=11]{biblatex}
 \addbibresource{references.bib}
-% for \thebibliography (switch in biblio.tex)
+\else
+% for \thebibliography (flag in info.tex)
 \patchcmd{\thebibliography}{\section *{\refname }}{\section{\refname}\label{sec:biblio}}{}{}
+\fi
 
 \newcommand{\collabletter}[1]{\includepdf[pages=-, pagecommand={\thispagestyle{empty}\rfoot{\thepage}}]{#1}\clearpage}
 
@@ -53,12 +59,15 @@
 \begin{document}
 % remove body header from first page
 \thispagestyle{empty}
+\hypersetup{pageanchor=false}
 % header/footer just on cover page
 \AddToShipoutPicture*{\BackgroundPic}
 \pagenumbering{gobble}
 
 \input{base/coverpage}
 \clearpage
+\hypersetup{pageanchor=true}
+
 \ifdefined\tocflag
 \thispagestyle{empty}
 \tableofcontents

--- a/main.tex
+++ b/main.tex
@@ -12,7 +12,15 @@
 \usepackage{lineno}
 \usepackage{array}
 \usepackage{etoolbox, pdfpages}
+
+% bibliography, NOFO says:
+% Each reference must include the names of all authors (in the same sequence in which they appear in the publication), the article and journal title, book title, volume number, page numbers, and year of publication. For research areas where there are routinely more than 10 coauthors of archival publications, you may use an abbreviated style such as the Physical Review Letters (PRL) convention for citations (listing only the first author). For example, your paper may be listed as, “A Really Important New Result,” A. Aardvark et. al. (MONGO Collaboration), PRL 999. Include only bibliographic citations. Applicants should be especially careful to follow scholarly practices in providing citations for source materials relied upon when preparing any section of the application.
+% for biblatex (default)
+\usepackage[backend=biber,style=nature,sorting=none,maxbibnames=11]{biblatex}
+\addbibresource{references.bib}
+% for \thebibliography (look in biblio.tex)
 \patchcmd{\thebibliography}{\section *{\refname }}{\section{\refname}\label{sec:biblio}}{}{}
+
 \newcommand{\collabletter}[1]{\includepdf[pages=-, pagecommand={\thispagestyle{empty}\rfoot{\thepage}}]{#1}\clearpage}
 \pdfminorversion=7
 

--- a/references.bib
+++ b/references.bib
@@ -1,0 +1,12 @@
+@report{p5_2023,
+  title = {Exploring the {{Quantum Universe}}: {{Pathways}} to {{Innovation}} and {{Discovery}} in {{Particle Physics}}},
+  shorttitle = {Exploring the {{Quantum Universe}}},
+  author = {Murayama, Hitoshi and Asai, Shoji and Heeger, Karsten and Ballarino, Amalia and Bose, Tulika and Cranmer, Kyle and Cyr-Racine, Francis-Yan and Demers, Sarah and Geddes, Cameron and Gershtein, Yuri and Heinemann, Beate and Hewett, JoAnne and Huber, Patrick and Mahn, Kendall and Mandelbaum, Rachel and Maricic, Jelena and Merkel, Petra and Monahan, Christopher and Onyisi, Peter and Palmer, Mark and Raubenheimer, Tor and Sanchez, Mayly and Schnee, Richard and Seidel, Sally and Seo, Seon-Hee and Thaler, Jesse and Touramanis, Christos and Vieregg, Abigail and Weinstein, Amanda and Winslow, Lindley and Yu, Tien-Tien and Zwaska, Robert},
+  date = {2023-06-07},
+  institution = {US Department of Energy (USDOE), Washington DC (United States). Energy Information Administration},
+  doi = {10.2172/2368847},
+  url = {https://www.osti.gov/biblio/2368847},
+  abstract = {Now more than ever, particle physics is an international, even global, endeavor. The experiments needed to address the most profound questions of our field often require resources and cooperation at a global scale and can take more than a decade to design and build. We found the scope of our charge and the responsibility it represents humbling. Throughout our deliberations, we were aware that the impact of our recommendations would be felt past the end of the next decade and beyond the borders of the US particle physics program. The recommended program reflects the consensus of the panel.},
+  langid = {english},
+}
+

--- a/references.bib
+++ b/references.bib
@@ -6,7 +6,6 @@
   institution = {US Department of Energy (USDOE), Washington DC (United States). Energy Information Administration},
   doi = {10.2172/2368847},
   url = {https://www.osti.gov/biblio/2368847},
-  abstract = {Now more than ever, particle physics is an international, even global, endeavor. The experiments needed to address the most profound questions of our field often require resources and cooperation at a global scale and can take more than a decade to design and build. We found the scope of our charge and the responsibility it represents humbling. Throughout our deliberations, we were aware that the impact of our recommendations would be felt past the end of the next decade and beyond the borders of the US particle physics program. The recommended program reflects the consensus of the panel.},
   langid = {english},
 }
 


### PR DESCRIPTION
changes for the 2025 NOFO that I didn't get around to merging:
* the "transparency of foreign connections" appendix is not needed for DOE labs, but it's ambiguous whether you should silently omit it or include one that just says "not needed" - the final consensus in 2025 was that the latter is safer
* a boilerplate statement on the Buy America preference

new changes for 2026:
* new Fermiab director and point of contact on cover page
* some changes to the wording on the cover page
* data management plan is now "data management and sharing plan"

other quality-of-life changes:
* add a line-numbering flag, might be useful when generating drafts for internal review
* use biblatex instead of manually formatting a bibliography (you can switch back to manual formatting if you prefer that)
* README has my notes on merging the signed cover page for final submission