### PR TITLE
Add flag to switch to numbered appendices

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository facilitates the combination of user content with central style and formatting provided by FNAL.
 
 Users should enter content in the following locations (items 4-8 cover the required appendices):
-1. [info.tex](./info.tex): details for cover page, and flags to enable/disable table of contents, line numbering, and biblatex 
+1. [info.tex](./info.tex): details for cover page, and flags to enable/disable table of contents, dots on table of contents, line numbering, biblatex, and numbered appendices
 2. [packages.tex](./packages.tex): any additional packages used
 3. [content.tex](./content.tex): the actual proposal content
 4. [biblio.tex](./biblio.tex): references

--- a/info.tex
+++ b/info.tex
@@ -2,14 +2,14 @@
 \def\Name{Jane Doe}
 \def\PhoneLast{xxxx}
 \def\EmailFirst{janedoe}
-\def\ProgramOffice{Enter value}
-\def\TopicArea{Enter value}
-\def\ProgramContact{Enter value}
-\def\YearPhD{2015}
+\def\ProgramOffice{Enter value} % Example: HEP; check NOFO for instructions
+\def\TopicArea{Enter value} % Example: Experimental Research at the Energy Frontier in High Energy Physics; check NOFO
+\def\ProgramContact{Enter value} % Example: Abid Patwa; Each topic/research area has a corresponding technical contact; check NOFO
+\def\YearPhD{20xx}
 \def\UnivTenureTrack{Not at a University}
 \def\PITenure{No}
-\def\NumPrev{0}
-\def\PreproposalNum{Enter value (format: PRE-xxxxxxxxxx)}
+\def\NumPrev{Enter value} % Either 0, 1, or 2
+\def\PreproposalNum{PRE-xxxxxxxxxx}
 
 % comment out below to disable table of contents
 \def\tocflag{}

--- a/info.tex
+++ b/info.tex
@@ -10,12 +10,21 @@
 \def\PITenure{No}
 \def\NumPrev{0}
 \def\PreproposalNum{PRE-0000000000}
+
 % comment out below to disable table of contents
 \def\tocflag{}
+
+% uncomment out below to remove dots from table of contents lines for subsection-depth and lower
+%\def\hidetocdotsflag{}
+
 % uncomment below to enable linenumbers
 %\def\linenoflag{}
+
 % comment out below to use \thebibliography (manual formatting) instead of biblatex
 \def\biblatexflag{}
+
+% uncomment out below to use arabic numerals to number appendices
+%\def\numberedappendicesflag{}
 
 % unlikely to change
 \def\PhoneFirst{630.840}

--- a/info.tex
+++ b/info.tex
@@ -4,12 +4,12 @@
 \def\EmailFirst{janedoe}
 \def\ProgramOffice{Enter value}
 \def\TopicArea{Enter value}
-\def\ProgramContact{John Snow}
+\def\ProgramContact{Enter value}
 \def\YearPhD{2015}
 \def\UnivTenureTrack{Not at a University}
 \def\PITenure{No}
 \def\NumPrev{0}
-\def\PreproposalNum{PRE-0000000000}
+\def\PreproposalNum{Enter value (format: PRE-xxxxxxxxxx)}
 
 % comment out below to disable table of contents
 \def\tocflag{}

--- a/info.tex
+++ b/info.tex
@@ -2,8 +2,8 @@
 \def\Name{Jane Doe}
 \def\PhoneLast{xxxx}
 \def\EmailFirst{janedoe}
-\def\ProgramOffice{DOE}
-\def\TopicArea{Physics}
+\def\ProgramOffice{Enter value}
+\def\TopicArea{Enter value}
 \def\ProgramContact{John Snow}
 \def\YearPhD{2015}
 \def\UnivTenureTrack{Not at a University}

--- a/main.tex
+++ b/main.tex
@@ -25,6 +25,26 @@
 \patchcmd{\thebibliography}{\section *{\refname }}{\section{\refname}\label{sec:biblio}}{}{}
 \fi
 
+\ifdefined\hidetocdotsflag
+% remove dots from toc
+\usepackage{tocloft}
+\renewcommand{\cftdot}{} % Hide dots from toc
+\fi
+
+\ifdefined\numberedappendicesflag
+% numbered appendices
+\makeatletter
+\newcommand\appendix@section[1]{%
+  \refstepcounter{section}%
+  \orig@section*{Appendix \@arabic\c@section: #1}%
+  \addcontentsline{toc}{section}{Appendix \@arabic\c@section: #1}%
+}
+\let\orig@section\section
+\g@addto@macro\appendix{\let\section\appendix@section}
+\makeatother
+\else
+\fi
+
 \newcommand{\collabletter}[1]{\includepdf[pages=-, pagecommand={\thispagestyle{empty}\rfoot{\thepage}}]{#1}\clearpage}
 
 % blank footnote for Buy America boilerplate

--- a/main.tex
+++ b/main.tex
@@ -42,7 +42,6 @@
 \let\orig@section\section
 \g@addto@macro\appendix{\let\section\appendix@section}
 \makeatother
-\else
 \fi
 
 \newcommand{\collabletter}[1]{\includepdf[pages=-, pagecommand={\thispagestyle{empty}\rfoot{\thepage}}]{#1}\clearpage}


### PR DESCRIPTION
Changes:
- PR title
- Add a flag to hide dots from the table of contents (for subsections, subsubsections, etc,)
- Remove realistic looking but incorrect entries from info.tex (I am the story behind this fix)